### PR TITLE
Prefer to keep cursor within a block in remove_node

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "name": "Core slate test",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "args": ["test:custom", "--grep=${fileBasenameNoExtension}"]
+    },
+    {
+      "type": "node",
+      "name": "All core slate tests (slate/test/index.js)",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "args": ["test:custom"]
+    }
+  ]
+}

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -150,11 +150,23 @@ const applyToDraft = (editor: Editor, selection: Selection, op: Operation) => {
               }
             }
 
+            // When the cursor's location is removed, generally we move the cursor back one position, except
+            // that we prioritize keeping the cursor on a direct sibling in where possible.
             let preferNext = false
             if (prev && next) {
-              if (Path.equals(next[1], path)) {
+              // If the removed node had a previous sibling, always prefer that.
+              if (Path.isSibling(prev[1], path)) {
+                preferNext = false
+              }
+              // If the subsequent node is exactly where the removed node was, then they were siblings. If
+              // it's the beginning of its containing block, leave the cursor there rather than move it
+              // backwards out of that block.
+              else if (Path.equals(next[1], path)) {
                 preferNext = !Path.hasPrevious(next[1])
-              } else {
+              }
+              // If neither prev or next are siblings of the removed node, then prefer whichever has the
+              // longest common path.
+              else {
                 preferNext =
                   Path.common(prev[1], path).length <
                   Path.common(next[1], path).length

--- a/packages/slate/test/normalization/text/merge-adjacent-empty-before-inline.tsx
+++ b/packages/slate/test/normalization/text/merge-adjacent-empty-before-inline.tsx
@@ -6,6 +6,7 @@ export const input = (
     <block>
       <text>not empty</text>
       <text a />
+      <cursor />
       <inline>inline</inline>
       <text />
     </block>
@@ -14,7 +15,10 @@ export const input = (
 export const output = (
   <editor>
     <block>
-      <text>not empty</text>
+      <text>
+        not empty
+        <cursor />
+      </text>
       <inline>inline</inline>
       <text />
     </block>

--- a/packages/slate/test/operations/remove_node/cursor-prefer-prior-sibling.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-prefer-prior-sibling.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+      <text />
+      <cursor />
+      <inline>text</inline>
+      <text />
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 1],
+    node: { text: '' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text />
+      <cursor />
+      <inline>text</inline>
+      <text />
+    </element>
+  </editor>
+)


### PR DESCRIPTION
**Description**
https://github.com/ianstormtaylor/slate/pull/4296 attempted to update remove_node (when removing the node with the cursor in it) to prefer to leave the cursor inside a given container block when possible, rather than always moving the cursor backwards (e.g. when the cursor is at the start of a line, don't jump it back to the previous line when the original line still isn't empty).

However, there is a bit of incorrect logic in there:

> However we have to special-case the situation where next[1] is the same as path (this arises because we recompute the selection after removing the node, so next[1] is the same as path whenever the deleted node has following siblings). In this case, next always has the longer common path, which breaks some existing tests. Instead, prefer next only when it has no previous sibling (so prev is not a sibling).

This is almost correct, but instead of looking at whether the _updated_ `next` path has a previous sibling, we need to check whether the _initial_ cursor path has a previous sibling - otherwise, if `next` is actually more deeply nested than the initial cursor, we will incorrectly see that it has no previous sibling and not move backwards.

In general, since moving the cursor backwards while keeping the hierarchy level constant is the default behavior, we can add a short-circuit check to this if-block that says anytime the removed node had a previous sibling, move the cursor to that sibling.

See tests for examples of what this fixes.  Verified that both new tests fail with the old logic.