### PR TITLE
Always prefer siblings

### DIFF
--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -161,11 +161,10 @@ const applyToDraft = (editor: Editor, selection: Selection, op: Operation) => {
               if (Path.isSibling(prev[1], path)) {
                 preferNext = false
               }
-              // If the subsequent node is exactly where the removed node was, then they were siblings. If
-              // it's the beginning of its containing block, leave the cursor there rather than move it
-              // backwards out of that block.
+              // If the subsequent node is exactly where the removed node was, then they were siblings. Since we
+              // know that the previous node is not a sibling, prefer it
               else if (Path.equals(next[1], path)) {
-                preferNext = !Path.hasPrevious(next[1])
+                preferNext = true
               }
               // If neither prev or next are siblings of the removed node, then prefer whichever has the
               // longest common path.

--- a/packages/slate/test/transforms/delete/point/inline-void-reverse.tsx
+++ b/packages/slate/test/transforms/delete/point/inline-void-reverse.tsx
@@ -25,10 +25,9 @@ export const output = (
     <block>
       <text />
       <inline void>
-        <text>
-          <cursor />
-        </text>
+        <text />
       </inline>
+      <cursor />
       word
     </block>
   </editor>


### PR DESCRIPTION
**Description**
Followup change to #2. We still had a few cases where it was jumping down into an inline object instead of preferring the sibling. Realize that the else case in our code was kind of a mix of the old and new logic, so patched it up to just prefer siblings always. Will apply this as a patch once merged

