### PR TITLE
Remove most isPlainObject checks

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -603,7 +603,7 @@ export const Editor: EditorInterface = {
       return cachedIsEditor
     }
 
-    if (!isPlainObject(value)) {
+    if (typeof value !== 'object') {
       return false
     }
 

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -1,4 +1,3 @@
-import { isPlainObject } from 'is-plain-object'
 import { Editor, Node, Path, Descendant, ExtendedType, Ancestor } from '..'
 
 /**
@@ -30,10 +29,8 @@ export interface ElementInterface {
  * Shared the function with isElementType utility
  */
 const isElement = (value: any): value is Element => {
-  return (
-    isPlainObject(value) &&
-    Node.isNodeList(value.children) &&
-    !Editor.isEditor(value)
+  return Boolean(
+    value && Node.isNodeList(value.children) && !Editor.isEditor(value)
   )
 }
 
@@ -44,7 +41,7 @@ export const Element: ElementInterface = {
    */
 
   isAncestor(value: any): value is Ancestor {
-    return isPlainObject(value) && Node.isNodeList(value.children)
+    return Node.isNodeList(value.children)
   },
 
   /**

--- a/packages/slate/src/interfaces/point.ts
+++ b/packages/slate/src/interfaces/point.ts
@@ -1,4 +1,3 @@
-import { isPlainObject } from 'is-plain-object'
 import { produce } from 'immer'
 import { ExtendedType, Operation, Path } from '..'
 import { TextDirection } from './types'
@@ -85,10 +84,8 @@ export const Point: PointInterface = {
    */
 
   isPoint(value: any): value is Point {
-    return (
-      isPlainObject(value) &&
-      typeof value.offset === 'number' &&
-      Path.isPath(value.path)
+    return Boolean(
+      value && typeof value.offset === 'number' && Path.isPath(value.path)
     )
   },
 

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -1,5 +1,4 @@
 import { produce } from 'immer'
-import { isPlainObject } from 'is-plain-object'
 import { ExtendedType, Operation, Path, Point, PointEntry } from '..'
 import { RangeDirection } from './types'
 
@@ -175,10 +174,8 @@ export const Range: RangeInterface = {
    */
 
   isRange(value: any): value is Range {
-    return (
-      isPlainObject(value) &&
-      Point.isPoint(value.anchor) &&
-      Point.isPoint(value.focus)
+    return Boolean(
+      value && Point.isPoint(value.anchor) && Point.isPoint(value.focus)
     )
   },
 

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -56,7 +56,7 @@ export const Text: TextInterface = {
    */
 
   isText(value: any): value is Text {
-    return isPlainObject(value) && typeof value.text === 'string'
+    return Boolean(value && typeof value.text === 'string')
   },
 
   /**

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -2,11 +2,12 @@ import assert from 'assert'
 import { fixtures } from '../../../support/fixtures'
 import { Editor } from 'slate'
 import { createHyperscript } from 'slate-hyperscript'
+import { isPlainObject } from 'is-plain-object'
 
 describe('slate', () => {
   fixtures(__dirname, 'interfaces', ({ module }) => {
     let { input, test, output } = module
-    if (Editor.isEditor(input)) {
+    if (isPlainObject(input) && Editor.isEditor(input)) {
       input = withTest(input)
     }
     const result = test(input)


### PR DESCRIPTION
As discussed here: https://staging.coda.io/d/_dTgmTD_HYPt#Prototype-Versions_tuUak/r21&view=modal

Various APIs use an `isPlainObject` check (`isText`, `isElement`, `isRange`, `isPoint`, etc). This appears to be a hot path. In our app we always pass in plain objects, and can trust TS a bit more than the library can. This change improves render time by around 2-3%.

I replaced most of these with truthy/existence checks, because it seems like there is code that relies on that.

WIP until I can get a proper patch generated in the main repo.